### PR TITLE
Add support for location lists

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -27,7 +27,7 @@ function! QFList(linenr)
             setlocal noswapfile
             setlocal readonly
         endif
-        
+
         highlight QuickrPreview ctermbg=darkgray ctermfg=yellow cterm=italic
         execute 'match QuickrPreview /\%'. l:entry.lnum .'l/'
 

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -57,6 +57,10 @@ function! GenerateBufferList()
     let s:buflist = []
     let s:qflist = getqflist()
 
+    if len(s:qflist) == 0
+        let s:qflist = getloclist(0)
+    fi
+
     for bufnum in range(1, bufnr('$'))
         if buflisted(bufnum)
             call add(s:buflist, bufnum)


### PR DESCRIPTION
Resolves the following error when using location lists...
```
Error detected while processing function QFList:
line    1:
E684: list index out of range: 0
E15: Invalid expression: s:qflist[a:linenr - 1]
line    4:
E121: Undefined variable: l:entry
E15: Invalid expression: l:entry.valid
Press ENTER or type command to continue
```