### PR TITLE
Highlighting the current line in the preview window

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,30 @@ For example:
 nmap <leader>q <plug>(quickr_preview_qf_close)
 ```
 
+#### Configuring the preview window sign column
+The symbol used in the sign column within the preview window can be disabled by
+adding the following to your `~/.vimrc` file.
+
+```vim
+let g:quickr_preview_sign_enable = 0
+```
+
+The symbol and highlight group used for the sign column within the preview window
+can be changed by adding the following to your `~/.vimrc` file.
+
+```vim
+let g:quickr_preview_sign_symbol = ">>"
+let g:quickr_preview_sign_hl = "SignColumn"
+```
+
+#### Configuring the preview window current line
+The highlight group used for the current line within the preview window can be
+changed by adding the following to your `~/.vimrc` file.
+
+```vim
+let g:quickr_preview_line_hl = "Search"
+```
+
 ### FAQ
 
 **Nothing happens when I press `<leader><space>` in quickfix/location window.**

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -40,8 +40,7 @@ function! QFList(linenr)
             setlocal nofoldenable       " disable folding
         endif
 
-        " Define a new sign for highlighting the line
-        sign define QuickrPreviewLine text=>> linehl=Search texthl=ErrorMsg
+        " Highlight the current line
         execute 'sign unplace 26'
         execute 'sign place 26 name=QuickrPreviewLine line=' . l:entry.lnum . ' buffer=' . l:entry.bufnr
 

--- a/plugin/quickr-preview.vim
+++ b/plugin/quickr-preview.vim
@@ -14,6 +14,18 @@ let g:quickr_preview_loaded = 1
 if !exists("g:quickr_preview_keymaps")
     let g:quickr_preview_keymaps = 1
 endif
+if !exists("g:quickr_preview_sign_enable")
+    let g:quickr_preview_sign_enable = 1
+endif
+if !exists("g:quickr_preview_sign_symbol")
+    let g:quickr_preview_sign_symbol = ">>"
+endif
+if !exists("g:quickr_preview_sign_hl")
+    let g:quickr_preview_sign_hl= "SignColumn"
+endif
+if !exists("g:quickr_preview_line_hl")
+    let g:quickr_preview_line_hl= "Search"
+endif
 " }}
 
 function! QuickrFixExit()
@@ -33,4 +45,8 @@ if g:quickr_preview_keymaps
 endif
 
 " Define a new sign for highlighting the current line in the preview window
-sign define QuickrPreviewLine text=>> linehl=Search texthl=ErrorMsg
+if g:quickr_preview_sign_enable
+    execute "sign define QuickrPreviewLine text=".g:quickr_preview_sign_symbol." texthl=".g:quickr_preview_sign_hl." linehl=".g:quickr_preview_line_hl
+else
+    execute "sign define QuickrPreviewLine linehl=".g:quickr_preview_line_hl
+endif

--- a/plugin/quickr-preview.vim
+++ b/plugin/quickr-preview.vim
@@ -31,3 +31,6 @@ nnoremap <silent> <plug>(quickr_preview_qf_close) :cclose<CR>
 if g:quickr_preview_keymaps
     nmap <leader>q <plug>(quickr_preview_qf_close)
 endif
+
+" Define a new sign for highlighting the current line in the preview window
+sign define QuickrPreviewLine text=>> linehl=Search texthl=ErrorMsg


### PR DESCRIPTION
The first patch prevents the highlighting definition from being re-defined each time the preview window is open. The second patch adds config options for changing highlight groups, as well as changing/disabling the symbol in the sign column.