### PR TITLE
Add an option to open preview split to the right

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ installed with a variety of plugin managers:
 <leader><space> : Preview the quickfix/location result in a preview window
 <enter>         : Open the quickfix/location result in a new buffer like usual
 ```
-P.S.: `\` is the leader key by default. So the mapping is `\<space>` unless `<leader>`
+P.S.: `\\` is the leader key by default. So the mapping is `\<space>` unless `<leader>`
 key is mapped to something else. Note that pressing `<leader><space>` multiple times on
 the same qiuckfix/location result will toggle the preview window.
 
@@ -73,7 +73,7 @@ nmap <leader>q <plug>(quickr_preview_qf_close)
 ```
 
 #### Configuring the preview window position
-By default, the preview window appears above the quickfix list.  But you can configure it to appear to the 'left', the 'right', or 'below' the quickfix list:
+By default, the preview window appears 'above' the quickfix list.  But you can configure it to appear to the 'left', the 'right', or 'below' the quickfix list:
 
 ```vim
 let g:quickr_preview_position = 'below'

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ For example:
 nmap <leader>q <plug>(quickr_preview_qf_close)
 ```
 
+#### Configuring the preview window position
+By default, the preview window appears above the quickfix list.  But you can configure it to appear to the 'left', the 'right', or 'below' the quickfix list:
+
+```vim
+let g:quickr_preview_position = 'below'
+```
+
 #### Configuring the preview window sign column
 The symbol used in the sign column within the preview window can be disabled by
 adding the following to your `~/.vimrc` file.

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -24,18 +24,15 @@ function! QFList(linenr)
     let l:entry = b:qflist[a:linenr - 1]
 
     if l:entry.valid
-        let extra = ''
-        if g:quickr_preview_position == 'left' || g:quickr_preview_position == 'right'
-            let extra = extra . 'vertical '
-        endif
-        if g:quickr_preview_position == 'below' || g:quickr_preview_position == 'right'
-            let extra = extra . 'belowright '
-        endif
+        let position = g:quickr_preview_position
 
-        execute extra . 'pedit +' . l:entry.lnum . ' ' . bufname(l:entry.bufnr)
+        let extra = position == 'below' || position == 'right' ? 'belowright ' : ''
+        let direction = position == 'left' || position == 'right' ? 'vsplit' : 'split'
 
-        " Jump to preview window
-        wincmd p
+        execute extra . direction . ' +' . l:entry.lnum . ' ' . bufname(l:entry.bufnr)
+
+        " Settings for preview window
+        setlocal previewwindow
         setlocal number
         setlocal norelativenumber
 

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -26,10 +26,10 @@ function! QFList(linenr)
     if l:entry.valid
         let position = g:quickr_preview_position
 
-        let extra = position == 'below' || position == 'right' ? 'belowright ' : ''
-        let direction = position == 'left' || position == 'right' ? 'vsplit' : 'split'
+        let axis = position == 'left' || position == 'right' ? 'vsplit' : 'split'
+        let side = position == 'below' || position == 'right' ? 'belowright' : 'aboveleft'
 
-        execute extra . direction . ' +' . l:entry.lnum . ' ' . bufname(l:entry.bufnr)
+        execute side . ' ' . axis . ' +' . l:entry.lnum . ' ' . bufname(l:entry.bufnr)
 
         " Settings for preview window
         setlocal previewwindow

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -24,7 +24,15 @@ function! QFList(linenr)
     let l:entry = b:qflist[a:linenr - 1]
 
     if l:entry.valid
-        execute 'pedit +' . l:entry.lnum . ' ' . bufname(l:entry.bufnr)
+        let extra = ''
+        if g:quickr_preview_position == 'left' || g:quickr_preview_position == 'right'
+            let extra = extra . 'vertical '
+        endif
+        if g:quickr_preview_position == 'below' || g:quickr_preview_position == 'right'
+            let extra = extra . 'belowright '
+        endif
+
+        execute extra . 'pedit +' . l:entry.lnum . ' ' . bufname(l:entry.bufnr)
 
         " Jump to preview window
         wincmd p

--- a/plugin/quickr-preview.vim
+++ b/plugin/quickr-preview.vim
@@ -26,6 +26,9 @@ endif
 if !exists("g:quickr_preview_line_hl")
     let g:quickr_preview_line_hl= "Search"
 endif
+if !exists("g:quickr_preview_position")
+    let g:quickr_preview_position = "above"
+endif
 " }}
 
 function! QuickrPreviewExit()


### PR DESCRIPTION
Love the script! But I really wanted the preview window to appear to the right of the quickfix list.

I added an option to achieve that:

```vim
let g:quickr_preview_position = 'right'
" or
let g:quickr_preview_position = 'below'
```