### PR TITLE
quickr_preview_exit_on_enter

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ If unspecified this option will default to the following:
 let g:quickr_preview_on_cursor = 0
 ```
 
+#### Auto-close quickfix on enter
+The option `g:quickr_preview_exit_on_enter` is used to define whether quickfix
+window will be automaticaly closed on enter or not. Valid values are zero
+(to disable) or one (to enable). If unspecified this option will default to the
+following:
+
+```vim
+let g:quickr_preview_exit_on_enter = 0
+```
+
 ### FAQ
 
 **Nothing happens when I press `<leader><space>` in quickfix/location window.**

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -240,6 +240,9 @@ function! HandleEnterQuickfix(linenr)
     execute "normal! \<cr>"
     " Open any folds we may be in
     silent! foldopen!
+    if g:quickr_preview_exit_on_enter
+        lclose
+    endif
 endfunction
 " }}
 

--- a/plugin/quickr-preview.vim
+++ b/plugin/quickr-preview.vim
@@ -29,6 +29,9 @@ endif
 if !exists('g:quickr_preview_on_cursor')
     let g:quickr_preview_on_cursor = 0
 endif
+if !exists('g:quickr_preview_exit_on_enter')
+    let g:quickr_preview_exit_on_enter = 0
+endif
 " }}
 
 " Construct the command used to open the preview window


### PR DESCRIPTION
New configuration option added: quickr_preview_exit_on_enter
When set to 1 quickfix window will be automatically closed when result chosen (enter pressed)
When set to 0 quickfix window will stay opened after choosing the result