### PR TITLE
add g:quickr_preview_modifiable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ following:
 let g:quickr_preview_exit_on_enter = 0
 ```
 
+#### Allow modification of the contents of the preview window
+The option `g:quickr_preview_modifiable` is used to define whether the quickfix
+window's contents are allowed to be modified. Valid values are zero (to
+disallow modification) or one (to enable modification). If unspecified this
+option will default to the following:
+
+```vim
+let g:quickr_preview_modifiable = 0
+```
+
 ### FAQ
 
 **Nothing happens when I press `<leader><space>` in quickfix/location window.**

--- a/plugin/quickr-preview.vim
+++ b/plugin/quickr-preview.vim
@@ -32,6 +32,9 @@ endif
 if !exists('g:quickr_preview_exit_on_enter')
     let g:quickr_preview_exit_on_enter = 0
 endif
+if !exists('g:quickr_preview_modifiable')
+    let g:quickr_preview_modifiable = 0
+endif
 " }}
 
 " Construct the command used to open the preview window
@@ -50,10 +53,12 @@ augroup QuickrPreviewAutoCmds
     " Select no-modifiable when moving to a buffer in the preview window
     autocmd BufEnter,WinEnter *
     \   if &previewwindow
-    \ |     if !exists('b:quickr_preview_modifiable')
-    \ |         let b:quickr_preview_modifiable = &modifiable
-    \ |         let &modifiable = 0
-    \ |    endif
+    \ |     if !g:quickr_preview_modifiable
+    \ |         if !exists('b:quickr_preview_modifiable')
+    \ |             let b:quickr_preview_modifiable = &modifiable
+    \ |             let &modifiable = 0
+    \ |         endif
+    \ |     endif
     \ | endif
     " Select modifiable when moving from a buffer in the preview window
     autocmd BufLeave,WinLeave *


### PR DESCRIPTION
This PR introduces an option to allow `&modifiable = 1` for the preview window. The default (preview window is not modifiable, i.e. `&modifiable = 0`) is kept for backward compatibility.