### PR TITLE
Fix closing preview when leaving quickfix

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -265,7 +265,7 @@ endfunction
 augroup QuickrPreviewQfAutoCmds
     autocmd! * <buffer>
     " Auto close preview window when closing/deleting the qf/loc list
-    autocmd BufDelete <buffer> silent! pclose
+    autocmd WinClosed <buffer> silent! pclose
     " Auto open preview window while scrolling through the qf/loc list
     if g:quickr_preview_on_cursor
         autocmd CursorMoved <buffer> nested silent call QFMove(line("."))


### PR DESCRIPTION
This should fix #22; previously, the preview was closed on the `BufDelete` event. However, as far as I can tell that isn't called on closing the quick fix window in Neovim or Vim 9.0. Instead, the `WinClosed` event works well for this.