### PR TITLE
Fix caching approach for Neovim

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -54,7 +54,7 @@ endfunction
 " if the qf/loc list has not yet been cached, or (for vim 8.1) if
 " it detects the qf/loc list has changed since it was last cached.
 "
-if v:version >= 801
+if (!has('nvim') && v:version >= 801) || has('nvim') 
     function! GetLatestQfLocList()
         if !exists('b:qftick')
             let b:qftick = -1


### PR DESCRIPTION
I was running into issues where it wasn't resetting the cached qflist in Neovim 0.8; using the algorithm recommended for vim >8.1 worked for me.

I'm not really sure at what point in Neovim's history each algorithm would work, so I just set a blanket check to use the vim 8.1 algorithm for all of Neovim 🤷🏻‍♂️ 